### PR TITLE
Fix invalid width value passed to AUtextInput

### DIFF
--- a/client/src/components/register/registerForm.tsx
+++ b/client/src/components/register/registerForm.tsx
@@ -112,7 +112,7 @@ export const RegisterForm: React.FC = () => {
             <TextField
               id="mobile"
               label="Contact number"
-              width="m"
+              width="md"
               type="text"
               required
             />


### PR DESCRIPTION
This pull request fixes an invalid value being passed for the `width` prop on the Register page.

> Warning: Failed prop type: Invalid prop `width` of value `m` supplied to `AUtextInput`, expected one of ["xs","sm","md","lg","xl"].