### PR TITLE
Fix null value being passed to AUselect

### DIFF
--- a/client/src/components/form/fields/SelectField.tsx
+++ b/client/src/components/form/fields/SelectField.tsx
@@ -24,9 +24,10 @@ interface SelectFieldProps {
 const SelectField: React.FC<SelectFieldProps> = (props: SelectFieldProps) => {
   const [field, meta] = useField({ name: props.id, ...props });
   const error = meta.touched && meta.error ? meta.error : "";
+  const status = error ? "invalid" : "valid"
 
   return (
-    <AuFormGroup status={error ? "invalid" : "valid"}>
+    <AuFormGroup status={status}>
       <AuLabel htmlFor={props.id} text={props.label} />
       {error && <AuErrorText text={meta.error} id={`${props.id}--error`} />}
       {props.hint && <AuHintText text={props.hint} />}
@@ -34,6 +35,7 @@ const SelectField: React.FC<SelectFieldProps> = (props: SelectFieldProps) => {
         {...props}
         {...field}
         aria-describedby={error && `${props.id}--error`}
+        status={status}
       />
     </AuFormGroup>
   );

--- a/client/src/hooks/lookupHook.ts
+++ b/client/src/hooks/lookupHook.ts
@@ -21,7 +21,7 @@ export const useLookupHook = (name: lookupType, label?: string) => {
       const result = await loadLookup(name);
       let data = result.data;
       if (label) {
-        data = [{ text: `Please select ${label}`, value: null }].concat(result.data);
+        data = [{ text: `Please select ${label}`, value: '' }].concat(result.data);
       }
       setLookupData({
         loaded: true,


### PR DESCRIPTION
This pull request fixes a null value being passed to the AUselect component.  The following warning is displayed on the Register page.

> Warning: Failed prop type: The prop `options[0].value` is marked as required in `AUselect`, but its value is `null`.