### PR TITLE
Add page alert to warn users not to post sensitive information

### DIFF
--- a/client/src/components/form/postOpportunity/postOpportunity.tsx
+++ b/client/src/components/form/postOpportunity/postOpportunity.tsx
@@ -151,6 +151,12 @@ const PostOpportunityForm: React.FC<{ opportunityId?: number }> = ({ opportunity
                       <ClientErrorDisplay errors={errors} />
                     )}
 
+                    <PageAlert type="info" className="max-30">
+                        <p>Do not post sensitive or classified information. The Digital Professions 
+                          will moderate site content, including the removal of content, in line with 
+                          the APS Code of Conduct.</p>
+                    </PageAlert>
+
                     <AuFieldset className="mt-2 mb-0">
                       <TextField
                         id="jobTitle"


### PR DESCRIPTION
This pull request adds a page alert on the post opportunity page.

<img width="687" alt="Screen Shot 2021-07-20 at 8 54 29 am" src="https://user-images.githubusercontent.com/2645932/126237780-63169b21-7c7a-4643-8179-0d72c19ed57a.png">
