### PR TITLE
Update content for successful publish of opportunity

### DIFF
--- a/client/src/pages/successfully-posted.tsx
+++ b/client/src/pages/successfully-posted.tsx
@@ -19,12 +19,20 @@ const View: React.FC<{opportunityId: number}> = ({ opportunityId }) => {
           {data.publishedAt && (
             <>
               <h1>Your opportunity is now live</h1>
-              <p>Your next steps</p>
+              <p>Your opportunity is now open for Commonwealth government employees to apply.</p>
+              <p>We encourage you to share it with anyone you think may be interested.</p>
+              <h2>Next steps</h2>
               <ul>
                 <li><Link to={`/opportunity/detail/?opportunityId=${opportunityId}`}>View</Link> your opportunity</li>
                 <li><Link to={`/post-opportunity/?opportunityId=${opportunityId}`}>Edit</Link> your opportunity</li>
                 <li><Link to="/post-opportunity">Post</Link> another opportunity</li>
               </ul>
+              <p>You will recieve notifications of applications for your opportunity by email.</p>
+              <p>How you decide on an applicant is up to you. We encourage you to organise a casual chat to make sure they are a good fit.</p>
+              <p>More information about <Link to={"/help-pages/5-matching"}>Matching an applicant</Link>.</p>
+              <h2>Share your feedback</h2>
+              <p>As this is a pilot, we appreciate your feedback so we can improve our service.</p>
+              <p><a href="https://dta.syd1.qualtrics.com/jfe/form/SV_5t2zgcu4m6VHT0O" rel="noopener noreferrer" target="_blank">Complete a 3 minute survey</a>.</p>
             </>
           )}
           {!data.publishedAt && (


### PR DESCRIPTION
This pull request updates the content on the page that's shown when a user successfully publishes an opportunity.

<img width="707" alt="Screen Shot 2021-07-20 at 11 21 46 am" src="https://user-images.githubusercontent.com/2645932/126248123-f0fecbe9-76dc-40b8-9441-0b3c7ea9f3a1.png">
