### PR TITLE
Use consistent casing when calling API routes

### DIFF
--- a/client/src/components/layouts/default-layout.tsx
+++ b/client/src/components/layouts/default-layout.tsx
@@ -98,7 +98,7 @@ const DefaultLayout: React.FC<Props> = ({
       }
       try {
         const result = await axios.get(
-          `/api/user/ping`, {
+          `/api/User/ping`, {
           headers: {
             'Authorization': `bearer ${session.token}`
           }

--- a/client/src/components/login/loginForm.tsx
+++ b/client/src/components/login/loginForm.tsx
@@ -29,7 +29,7 @@ export const LoginForm: React.FC<LoginProps> = ({ fromPage }: LoginProps) => {
     const { email, password } = formData;
     user.updateToken();
     try {
-      const result = await axios.post(`/api/user/authenticate`, {
+      const result = await axios.post(`/api/User/authenticate`, {
         EmailAddress: email,
         password,
       });

--- a/client/src/components/register/registerForm.tsx
+++ b/client/src/components/register/registerForm.tsx
@@ -24,7 +24,7 @@ export const RegisterForm: React.FC = () => {
     setErrorList([]);
     const { emailAddress, password, name, agency, mobile } = formData;
     try {
-      const result = await axios.post(`/api/user/register`, {
+      const result = await axios.post(`/api/User/register`, {
         name,
         emailAddress,
         password,

--- a/client/src/services/lookupService.ts
+++ b/client/src/services/lookupService.ts
@@ -10,7 +10,7 @@ export const loadLookup = async (name: lookupType) => {
     })
   }
 
-  return await axios.get(`/api/lookup`, {
+  return await axios.get(`/api/Lookup`, {
     params: {
       name,
     },

--- a/client/src/services/opportunityResponseService.ts
+++ b/client/src/services/opportunityResponseService.ts
@@ -74,7 +74,7 @@ export const uploadFile = async (id: number, toSave: FormData, token: string) =>
 
 
 export const downloadFile = async (id: number, filename: string, token: string) => {
-  const result = await axios.get(`/api/opportunityresponse/${id}/download?filename=${filename}`, {
+  const result = await axios.get(`/api/OpportunityResponse/${id}/download?filename=${filename}`, {
     responseType: 'blob',
     headers: {
       Authorization: `bearer ${token}`,


### PR DESCRIPTION
This pull request updates the casing of routes used by the front-end to match the controllers defined in the API.