### PR TITLE
MEMSA-701: Remove opportunity guidance content

### DIFF
--- a/client/src/pages/opportunity-guidance.tsx
+++ b/client/src/pages/opportunity-guidance.tsx
@@ -64,8 +64,6 @@ const OpportunityGuidancePage: React.FC<PageContext> = ({
           <p>For more information, see <Link to="/help-pages/3-creating-an-opportunity/">Creating an opportunity</Link>.</p>
         </section>
         <section>
-          <h2 id="shape-the-future" className="au-display-md">Help us shape the future of this initiative</h2>
-          <p>We will get in touch to seek your feedback and provide support.</p>
           <Link className="au-btn margin-top-1" to="/post-opportunity">Continue</Link>
         </section>
       </>

--- a/client/src/pages/opportunity-guidance.tsx
+++ b/client/src/pages/opportunity-guidance.tsx
@@ -64,7 +64,7 @@ const OpportunityGuidancePage: React.FC<PageContext> = ({
           <p>For more information, see <Link to="/help-pages/3-creating-an-opportunity/">Creating an opportunity</Link>.</p>
         </section>
         <section>
-          <Link className="au-btn margin-top-1" to="/post-opportunity">Continue</Link>
+          <Link className="au-btn margin-top-1" to="/post-opportunity">Continue to post opportunity</Link>
         </section>
       </>
     </DefaultLayout>


### PR DESCRIPTION
This pull request removes the section about helping to shape the future of oneAPS as similar content is displayed when an opportunity is posted.  It also updates the button text to make it clearer what action the user should take next.