### PR TITLE
Allow edu.au email addresses

### DIFF
--- a/api/Business.Impl/Validators/AuthenticateModelValidator.cs
+++ b/api/Business.Impl/Validators/AuthenticateModelValidator.cs
@@ -4,7 +4,7 @@ using Dta.OneAps.Api.Business.Models;
 namespace Dta.OneAps.Api.Business.Validators {
     public class AuthenticateModelValidator : AbstractValidator<AuthenticateUserRequest> {
         public AuthenticateModelValidator() {
-            RuleFor(u => u.EmailAddress).NotEmpty().Matches(".+@.+\\.gov\\.au").WithMessage("'Email Address' must be a gov.au email.");
+            RuleFor(u => u.EmailAddress).NotEmpty().Matches(".+@.+(\\.edu\\.au|\\.gov\\.au)").WithMessage("'Email Address' must be a gov.au email.");
             RuleFor(u => u.Password).NotEmpty();
         }
     }

--- a/api/Business.Impl/Validators/AuthenticateModelValidator.cs
+++ b/api/Business.Impl/Validators/AuthenticateModelValidator.cs
@@ -4,7 +4,11 @@ using Dta.OneAps.Api.Business.Models;
 namespace Dta.OneAps.Api.Business.Validators {
     public class AuthenticateModelValidator : AbstractValidator<AuthenticateUserRequest> {
         public AuthenticateModelValidator() {
-            RuleFor(u => u.EmailAddress).NotEmpty().Matches(".+@.+(\\.edu\\.au|\\.gov\\.au)").WithMessage("'Email Address' must be a gov.au email.");
+            RuleFor(u => u.EmailAddress)
+            .NotEmpty()
+            .Matches(".+@.+(\\.edu\\.au|\\.gov\\.au)")
+            .WithMessage("'Email Address' must be a gov.au email.");
+
             RuleFor(u => u.Password).NotEmpty();
         }
     }

--- a/api/Business.Impl/Validators/AuthenticateModelValidator.cs
+++ b/api/Business.Impl/Validators/AuthenticateModelValidator.cs
@@ -7,7 +7,7 @@ namespace Dta.OneAps.Api.Business.Validators {
             RuleFor(u => u.EmailAddress)
             .NotEmpty()
             .Matches(".+@.+(\\.edu\\.au|\\.gov\\.au)")
-            .WithMessage("'Email Address' must be a gov.au email.");
+            .WithMessage("'Email Address' must be an Australian government email.");
 
             RuleFor(u => u.Password).NotEmpty();
         }

--- a/api/Business.Impl/Validators/CreateUserModelValidator.cs
+++ b/api/Business.Impl/Validators/CreateUserModelValidator.cs
@@ -6,16 +6,24 @@ namespace Dta.OneAps.Api.Business.Validators {
     public class CreateUserModelValidator : AbstractValidator<UserCreateRequest> {
         public CreateUserModelValidator(ILookupService lookupService) {
             RuleFor(u => u.Name).NotEmpty();
-            RuleFor(u => u.Mobile).NotEmpty().MaximumLength(10);
+            
+            RuleFor(u => u.Mobile)
+            .NotEmpty()
+            .MaximumLength(10);
+            
             RuleFor(u => u.EmailAddress)
-                .NotEmpty()
-                .Matches(".+@.+(\\.edu\\.au|\\.gov\\.au)").WithMessage("{PropertyValue} must be a gov.au {PropertyName}");
+            .NotEmpty()
+            .Matches(".+@.+(\\.edu\\.au|\\.gov\\.au)")
+            .WithMessage("{PropertyValue} must be a gov.au {PropertyName}");
+            
             RuleFor(u => u.Agency)
-                .NotEmpty()
-                .Must(e => lookupService.Get("Agency", e) != null).WithMessage("{PropertyValue} is not a valid {PropertyName}.");
+            .NotEmpty()
+            .Must(e => lookupService.Get("Agency", e) != null)
+            .WithMessage("{PropertyValue} is not a valid {PropertyName}.");
+            
             RuleFor(u => u.Password)
-                .NotEmpty()
-                .MinimumLength(8);
+            .NotEmpty()
+            .MinimumLength(8);
         }
     }
 }

--- a/api/Business.Impl/Validators/CreateUserModelValidator.cs
+++ b/api/Business.Impl/Validators/CreateUserModelValidator.cs
@@ -9,7 +9,7 @@ namespace Dta.OneAps.Api.Business.Validators {
             RuleFor(u => u.Mobile).NotEmpty().MaximumLength(10);
             RuleFor(u => u.EmailAddress)
                 .NotEmpty()
-                .Matches(".+@.+\\.gov\\.au").WithMessage("{PropertyValue} must be a gov.au {PropertyName}");
+                .Matches(".+@.+(\\.edu\\.au|\\.gov\\.au)").WithMessage("{PropertyValue} must be a gov.au {PropertyName}");
             RuleFor(u => u.Agency)
                 .NotEmpty()
                 .Must(e => lookupService.Get("Agency", e) != null).WithMessage("{PropertyValue} is not a valid {PropertyName}.");

--- a/api/Business.Impl/Validators/CreateUserModelValidator.cs
+++ b/api/Business.Impl/Validators/CreateUserModelValidator.cs
@@ -14,7 +14,7 @@ namespace Dta.OneAps.Api.Business.Validators {
             RuleFor(u => u.EmailAddress)
             .NotEmpty()
             .Matches(".+@.+(\\.edu\\.au|\\.gov\\.au)")
-            .WithMessage("{PropertyValue} must be a gov.au {PropertyName}");
+            .WithMessage("{PropertyValue} must be an Australian government {PropertyName}");
             
             RuleFor(u => u.Agency)
             .NotEmpty()

--- a/client/src/components/register/registerForm.tsx
+++ b/client/src/components/register/registerForm.tsx
@@ -105,7 +105,7 @@ export const RegisterForm: React.FC = () => {
               id="emailAddress"
               label="Email"
               width="lg"
-              hint="You must have a gov.au email address to register"
+              hint="You must have an Australian government email address to register"
               type="email"
               required
             />

--- a/client/src/util/yup.ts
+++ b/client/src/util/yup.ts
@@ -5,7 +5,7 @@ export const emailValidation = yup
   .email("Enter a valid email")
   .required("Email is required")
   .max(255)
-  .matches(/.gov.au$/, "Only government emails are allowed to apply");
+  .matches(/\.gov\.au$/, "Only government emails are allowed to apply");
 
 export const passwordValidation = yup
   .string()

--- a/client/src/util/yup.ts
+++ b/client/src/util/yup.ts
@@ -5,7 +5,7 @@ export const emailValidation = yup
   .email("Enter a valid email")
   .required("Email is required")
   .max(255)
-  .matches(/\.gov\.au$/, "Only government emails are allowed to apply");
+  .matches(/.+@.+(\.edu\.au|\.gov\.au)$/, "Only government emails are allowed to apply");
 
 export const passwordValidation = yup
   .string()

--- a/client/src/util/yup.ts
+++ b/client/src/util/yup.ts
@@ -5,7 +5,7 @@ export const emailValidation = yup
   .email("Enter a valid email")
   .required("Email is required")
   .max(255)
-  .matches(/.+@.+(\.edu\.au|\.gov\.au)$/, "Only government emails are allowed to apply");
+  .matches(/.+@.+(\.edu\.au|\.gov\.au)$/, "Only Australian government emails are allowed to apply");
 
 export const passwordValidation = yup
   .string()


### PR DESCRIPTION
This pull request allows users to sign up to oneAPS with edu.au email addresses.  It also makes some of the email validation messages more generic.