### PR TITLE
Replace references to DTA with APSC

### DIFF
--- a/api/Services.Notify/NotifyService.cs
+++ b/api/Services.Notify/NotifyService.cs
@@ -60,13 +60,13 @@ Your application for “{opportunity.JobTitle}” has been received.
 The opportunity creator will be in contact regarding the results of the opportunity.
 Good luck on your application!
 
-If you have any questions, please contact specialist.advice@dta.gov.au.
+If you have any questions, please contact specialist.advice@apsc.gov.au.
 
 Regards
 
 Specialist Advice and Mobility Team
 Digital Profession
-specialist.advice@dta.gov.au
+specialist.advice@apsc.gov.au
 "},
             };
             
@@ -86,13 +86,13 @@ You have received an application for “{opportunity.JobTitle}”.
 
 The response to the application can be viewed in your profile.
 
-If you have any questions, please contact specialist.advice@dta.gov.au.
+If you have any questions, please contact specialist.advice@apsc.gov.au.
 
 Regards
 
 Specialist Advice and Mobility Team
 Digital Profession
-specialist.advice@dta.gov.au
+specialist.advice@apsc.gov.au
 "},
             };
             
@@ -121,7 +121,7 @@ Regards
 
 Specialist Advice and Mobility Team
 Digital Profession
-specialist.advice@dta.gov.au
+specialist.advice@apsc.gov.au
 "},
             };
 
@@ -146,7 +146,7 @@ Regards
 
 Specialist Advice and Mobility Team
 Digital Profession
-specialist.advice@dta.gov.au
+specialist.advice@apsc.gov.au
 "},
             };
 
@@ -175,7 +175,7 @@ Regards
 
 Specialist Advice and Mobility Team
 Digital Profession
-specialist.advice@dta.gov.au
+specialist.advice@apsc.gov.au
 "},
             };
 
@@ -198,7 +198,7 @@ Regards
 
 Specialist Advice and Mobility Team
 Digital Profession
-specialist.advice@dta.gov.au
+specialist.advice@apsc.gov.au
 "},
             };
 

--- a/client/gatsby-config.js
+++ b/client/gatsby-config.js
@@ -8,7 +8,7 @@ module.exports = {
     description: `A place to find flexible work opportunities across the APS to
     help deliver outcomes for government and the citizens we all
     serve.`,
-    author: `Digital Transformation Agency`,
+    author: `Australian Public Service Commission`,
     siteUrl: `https://oneAPS.gov.au/`,
     footerLinks: [
       {

--- a/client/src/components/layouts/default-layout.tsx
+++ b/client/src/components/layouts/default-layout.tsx
@@ -140,7 +140,7 @@ const DefaultLayout: React.FC<Props> = ({
           <div style={{background: '#c91a78', color: '#fff'}}>
             <div className="container" style={{padding: '5px 0px' }}>
               <span style={{background: '#000', padding: '3px', textTransform: 'uppercase', fontWeight: 'bolder', marginRight: '5px'}}>Pilot</span>
-              OneAPS is under active development and your feedback will help us improve it. Contact <a style={{color: '#fff'}} href="mailto:specialist.advice@dta.gov.au">specialist.advice@dta.gov.au</a>
+              OneAPS is under active development and your feedback will help us improve it. Contact <a style={{color: '#fff'}} href="mailto:specialist.advice@apsc.gov.au">specialist.advice@apsc.gov.au</a>
             </div>
           </div>
           <div>
@@ -158,7 +158,7 @@ const DefaultLayout: React.FC<Props> = ({
           This is part of a pilot program run by the Digital Profession team at the Digital Transformation Agency.
           <br />
           If you have any questions or feedback, please contact us at{" "}
-          <a href="mailto:specialist.advice@dta.gov.au">specialist.advice@dta.gov.au</a>
+          <a href="mailto:specialist.advice@apsc.gov.au">specialist.advice@apsc.gov.au</a>
         </div>
         <div style={{ marginTop: '1em', marginBottom: '3em' }}>
           <Footer path={location.pathname} />

--- a/client/src/components/layouts/default-layout.tsx
+++ b/client/src/components/layouts/default-layout.tsx
@@ -155,7 +155,7 @@ const DefaultLayout: React.FC<Props> = ({
             {children}
         </div>
         <div className="center-align">
-          This is part of a pilot program run by the Digital Profession team at the Digital Transformation Agency.
+          This is part of a pilot program run by the Digital Profession team at the Australian Public Service Commission.
           <br />
           If you have any questions or feedback, please contact us at{" "}
           <a href="mailto:specialist.advice@apsc.gov.au">specialist.advice@apsc.gov.au</a>

--- a/client/src/components/navigation/footer.tsx
+++ b/client/src/components/navigation/footer.tsx
@@ -71,7 +71,7 @@ const Footer: React.FC<Props> = ({ path }) => {
                 <div className="col-md-3 col-md-pull-9">
                   <p className="footer__affiliate">
                     <span>An initiative of the </span>
-                    <span>Digital Transformation Agency </span>
+                    <span>Australian Public Service Commission </span>
                     <span className="footer__affiliate-link">
                       <a
                         className="au-cta-link  au-cta-link--dark"

--- a/client/src/components/navigation/footer.tsx
+++ b/client/src/components/navigation/footer.tsx
@@ -36,7 +36,7 @@ const Footer: React.FC<Props> = ({ path }) => {
           <div className="container-fluid">
             <FooterNav>
               <div className="row">
-                <div className="col-md-offset-1 col-md-8 col-md-push-3">
+                <div className="col-md-8 col-md-push-4">
                   <h4>Community</h4>
                   <ul className="au-link-list au-link-list--inline">
                     {Links.map((item: any, i: number) => (
@@ -68,18 +68,10 @@ const Footer: React.FC<Props> = ({ path }) => {
                     </p>
                   </FooterEnd>
                 </div>
-                <div className="col-md-3 col-md-pull-9">
+                <div className="col-md-4 col-md-pull-8">
                   <p className="footer__affiliate">
                     <span>An initiative of the </span>
                     <span>Australian Public Service Commission </span>
-                    <span className="footer__affiliate-link">
-                      <a
-                        className="au-cta-link  au-cta-link--dark"
-                        href="https://www.dta.gov.au/our-projects"
-                      >
-                        More projects
-                      </a>
-                    </span>
                   </p>
                 </div>
               </div>

--- a/client/src/pages/about.tsx
+++ b/client/src/pages/about.tsx
@@ -29,7 +29,7 @@ const AboutPage: React.FC<PageContext> = ({ pageContext, location }) => {
         <div className="col-sm-12 col-md-6 col-md-pull-6">
           <h2>What oneAPS is</h2>
           <p>
-            As part of the <a href="https://www.dta.gov.au/help-and-advice/digital-profession/join-digital-profession" target="_blank">Digital Profession</a>, our Digital Profession team are trialing a whole-of-government program called oneAPS Opportunities (working title). This program aims to assist agencies to come together to work on government priorities and uplift digital capabilities through digital talent mobility.
+            As part of the <a href="https://www.digitalprofession.gov.au/join-digital-profession" rel="noopener" target="_blank">Digital Profession</a>, our Digital Profession team are trialing a whole-of-government program called oneAPS Opportunities (working title). This program aims to assist agencies to come together to work on government priorities and uplift digital capabilities through digital talent mobility.
           </p>
           <h2>What the program does</h2>
           <p>

--- a/client/src/pages/forget-password/success.tsx
+++ b/client/src/pages/forget-password/success.tsx
@@ -11,7 +11,7 @@ const Content: React.FC<{opportunityId: number}> = ({opportunityId}) => {
     <>
       <h1>Your password is updated successfully</h1>
       <p>You can now <Link to="/login">login</Link> with your email address and updated password</p>
-      <p>If you have any questions, please contact <a href="mailto:specialist.advice@dta.gov.au">specialist.advice@dta.gov.au</a>.</p>
+      <p>If you have any questions, please contact <a href="mailto:specialist.advice@apsc.gov.au">specialist.advice@apsc.gov.au</a>.</p>
     </>
   );
 }

--- a/client/src/pages/help-pages/1-about-oneaps.md
+++ b/client/src/pages/help-pages/1-about-oneaps.md
@@ -14,7 +14,7 @@ layout: help
 
 ## <span id="What-is-oneAPS-Opportunities">What is oneAPS Opportunities?</span>
 
-As part of the <a href="https://www.dta.gov.au/help-and-advice/digital-profession" target="_blank" rel="external noreferrer">Digital Profession</a>, the DTA are trialling a new approach to uplift skills through digital talent mobility. 
+The <a href="https://www.digitalprofession.gov.au/" target="_blank" rel="external noreferrer">Digital Profession</a> is trialling a new approach to uplift skills through digital talent mobility. 
 
 oneAPS Opportunities enables managers to access digital professionals from across the Federal Government to assist with short-term flexible work opportunities.
 

--- a/client/src/pages/help-pages/2-how-it-works.md
+++ b/client/src/pages/help-pages/2-how-it-works.md
@@ -38,4 +38,4 @@ As this is a pilot, we will have a few touchpoints along the way to get your fee
 
 We will also encourage you to share your story when the opportunity is completed.
 
-If you have any questions or feedback, please contact us at <a href="mailto:specialist.advice@dta.gov.au" target="_blank" rel="external noreferrer">specialist.advice@dta.gov.au</a>
+If you have any questions or feedback, please contact us at <a href="mailto:specialist.advice@apsc.gov.au" target="_blank" rel="external noreferrer">specialist.advice@apsc.gov.au</a>

--- a/client/src/pages/help-pages/3-creating-an-opportunity.md
+++ b/client/src/pages/help-pages/3-creating-an-opportunity.md
@@ -19,9 +19,10 @@ There are many types of digital opportunities you can post, depending on what yo
 
 We encourage opportunities that are:
 
-- From a couple of hours to a few days or a few months
-- Able to offer flexible working arrangements (for example, completed remotely) 
-- Focused on digital and data skills and capabilities (ICT capabilities and human-centred capabilities such as design and research).
+- A few hours or days to a few months long
+- Seeking digital or data skills
+- Able to be completed flexibly by remote working or part-time
+- Do not need onboarding to your organisation’s ICT systems
 
 Examples include: 
 
@@ -33,7 +34,14 @@ Examples include:
 - Subject matter expert advice
 - Event volunteers
 
-Not sure exactly what skills you are looking for? Feel free to get in touch with the Specialist Advice and Mobility Team at <a href="mailto:specialist.advice@dta.gov.au" target="_blank" rel="external noreferrer">specialist.advice@dta.gov.au</a>
+The following opportunities do not fit the program:
+
+- Secondments or temporary transfers
+- Opportunities where there is a change to pay and conditions
+- Time sensitive or high-risk opportunities
+- Opportunities which contain Sensitive or Classified information
+
+Not sure exactly what skills you are looking for? Feel free to get in touch with us at <a href="mailto:specialist.advice@apsc.gov.au" target="_blank" rel="external noreferrer">specialist.advice@apsc.gov.au</a>
 
 ## <span id="Posting-an-opportunity-is-quick-and-easy">Posting an opportunity is quick and easy</span> 
 

--- a/client/src/pages/help-pages/5-onboarding.md
+++ b/client/src/pages/help-pages/5-onboarding.md
@@ -10,7 +10,7 @@ layout: help
 
 ## Contact the DTA
 
-When the successful opportunity participant has been chosen and notified, please contact the [DTA Specialist Advice and Mobility](mailto:specialist.advice@dta.gov.au "email") team to let us know.
+When you have chosen and notified your opportunity participant, please contact our team at [specialist.advice@apsc.gov.au](mailto:specialist.advice@apsc.gov.au "email") team to let us know.
 
 ## <span id="before_the_move">Before the move</span>
 

--- a/client/src/pages/help-pages/5-onboarding.md
+++ b/client/src/pages/help-pages/5-onboarding.md
@@ -10,7 +10,7 @@ layout: help
 
 ## Contact the APSC
 
-When you have chosen and notified your opportunity participant, please contact our team at [specialist.advice@apsc.gov.au](mailto:specialist.advice@apsc.gov.au "email") team to let us know.
+When you have chosen and notified your opportunity participant, please contact our team at [specialist.advice@apsc.gov.au](mailto:specialist.advice@apsc.gov.au "email") to let us know.
 
 ## <span id="before_the_move">Before the move</span>
 

--- a/client/src/pages/help-pages/5-onboarding.md
+++ b/client/src/pages/help-pages/5-onboarding.md
@@ -8,7 +8,7 @@ layout: help
 * [Getting started on their first day](#get_started_first_day)
 * [Supporting temporary team members](#support_temp_team_members)
 
-## Contact the DTA
+## Contact the APSC
 
 When you have chosen and notified your opportunity participant, please contact our team at [specialist.advice@apsc.gov.au](mailto:specialist.advice@apsc.gov.au "email") team to let us know.
 

--- a/client/src/pages/help-pages/6-offboarding.md
+++ b/client/src/pages/help-pages/6-offboarding.md
@@ -11,6 +11,6 @@ At this stage you may consider:
 
 ## Providing feedback and sharing your story
 
-As this is a pilot, the DTA Specialist Advice and Mobility team may wish to interview key people involved to understand their experiences and their feedback on how to improve the program.
+As this is a pilot, the APSC Specialist Advice and Mobility team may wish to interview key people involved to understand their experiences and their feedback on how to improve the program.
 
 If you enjoyed the program, we would appreciate if you would encourage other colleagues to get involved.  

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -20,7 +20,7 @@ const IndexPage: React.FC<PageContext> = ({ pageContext, location }) => {
                 <p>
                   This site is part of a pilot program run by the Digital Profession at the Digital Transformation Agency.
                 </p>
-                <p>If you have any questions or feedback, please contact us at <a href="mailto:specialist.advice@dta.gov.au">specialist.advice@dta.gov.au</a></p>
+                <p>If you have any questions or feedback, please contact us at <a href="mailto:specialist.advice@apsc.gov.au">specialist.advice@apsc.gov.au</a></p>
               </>
             </PageAlert>
           </section>

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -18,7 +18,7 @@ const IndexPage: React.FC<PageContext> = ({ pageContext, location }) => {
               <>
                 <h2>A Digital Profession pilot program</h2>
                 <p>
-                  This site is part of a pilot program run by the Digital Profession at the Digital Transformation Agency.
+                  This site is part of a pilot program run by the Digital Profession at the Australian Public Service Commission.
                 </p>
                 <p>If you have any questions or feedback, please contact us at <a href="mailto:specialist.advice@apsc.gov.au">specialist.advice@apsc.gov.au</a></p>
               </>

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -46,7 +46,7 @@ const IndexPage: React.FC<PageContext> = ({ pageContext, location }) => {
                 You can choose to post an opportunity or apply for an opportunity.
               </p>
               <div style={{ marginTop: "3rem", marginBottom: "3rem" }}>
-                Check out our <a target="_blank" href="https://www.dta.gov.au/blogs/broadening-horizons-through-oneaps-opportunity">blog post</a> for a story of an opportunity in action.
+                Check out our <a target="_blank" href="https://www.digitalprofession.gov.au/blog/using-oneaps-uplift-team-skills-and-knowledge" rel="noopener">blog post</a> for a story of an opportunity in action.
               </div>
               <div>
                 <Link to="/opportunity" className="au-btn">Find opportunities</Link>

--- a/client/src/pages/privacy.md
+++ b/client/src/pages/privacy.md
@@ -11,7 +11,7 @@ The Privacy Act 1988 requires us to have a privacy policy. This privacy policy o
 
 **Personal information** is information or an opinion about an identified individual or an individual who is reasonably identifiable. 
 
-This policy is written in simple language. This policy applies to the oneAPS Opportunities pilot website managed by the Digital Transformation Agency (DTA). 
+This policy is written in simple language. This policy applies to the oneAPS Opportunities pilot website managed by the Australian Public Service Commission (APSC). 
 
 ## What we collect 
 

--- a/client/src/pages/privacy.md
+++ b/client/src/pages/privacy.md
@@ -180,14 +180,20 @@ Requests for access to your own personal information are free.
 Request for your own personal information may be made to: 
 
 **Email** 
-<a href="mailto:foi@dta.gov.au">foi@dta.gov.au</a>
+<a href="mailto:foi@apsc.gov.au">foi@apsc.gov.au</a>
    
 **Post**  
-FOI Officer  
-Digital Transformation Agency  
-PO Box 457  
-Canberra City 
-ACT 2601
+FOI Contact Officer  
+Australian Public Service Commission  
+B Block, Treasury Building, Parkes Place West  
+Parkes ACT 2600
+
+or  
+
+FOI Contact Officer  
+Australian Public Service Commission  
+GPO Box 3176  
+Canberra ACT 2601  
 
 We will respond to request to access (and where relevant, correct) your own personal information within 30 days of receiving the request.  If we are required or permitted to refuse access, we will give you a written notice setting out: 
 

--- a/client/src/pages/privacy.md
+++ b/client/src/pages/privacy.md
@@ -203,19 +203,12 @@ We will respond to request to access (and where relevant, correct) your own pers
 
 ## How to make a complaint 
 
-If you wish to make a complaint about how the DTA has handled your personal information, please do so in writing.  If you need help lodging a complaint, you can contact the Privacy Officer on 02 6120 8595. 
+If you wish to make a complaint about how the DTA has handled your personal information, please do so in writing.
 
 Complaints can be made to: 
 
 **Email** 
-<a href="mailto:privacy@dta.gov.au">privacy@dta.gov.au</a>
-
-**Post**  
-Privacy Officer  
-Digital Transformation Agency  
-PO Box 457  
-Canberra City 
-ACT 2601 
+<a href="mailto:privacy@apsc.gov.au">privacy@apsc.gov.au</a>
 
 If we receive a complaint from you, we will acknowledge your complaint within 3 business days of receiving the complaint.   
 

--- a/client/src/pages/privacy.md
+++ b/client/src/pages/privacy.md
@@ -151,7 +151,7 @@ We also review the quality of personal information before we use or disclose it.
 
 This site is hosted and stored in Australia in secure, government-accredited facilities. To help protect the privacy of the data and personal information we collect and hold, we maintain physical, technical and administrative safeguards. 
 
-Access to your personal information is restricted to DTA employees working on the oneAPS Opportunities pilot who need it to provide services to you and to the Opportunity creator who is seeking a person to fulfill their opportunity. We take steps to protect the security of the personal information we hold from both internal and external threats by: 
+Access to your personal information is restricted to APSC employees working on the oneAPS Opportunities pilot who need it to provide services to you and to the Opportunity creator who is seeking a person to fulfill their opportunity. We take steps to protect the security of the personal information we hold from both internal and external threats by: 
 
 * regularly assessing the risk of misuse, interference, loss, and unauthorised access, modification or disclosure of that information 
 
@@ -203,7 +203,7 @@ We will respond to request to access (and where relevant, correct) your own pers
 
 ## How to make a complaint 
 
-If you wish to make a complaint about how the DTA has handled your personal information, please do so in writing.
+If you wish to make a complaint about how the APSC has handled your personal information, please do so in writing.
 
 Complaints can be made to: 
 
@@ -212,7 +212,7 @@ Complaints can be made to:
 
 If we receive a complaint from you, we will acknowledge your complaint within 3 business days of receiving the complaint.   
 
-We will respond to your complaint within 30 days (or another timeframe agreed with you) of receiving your complaint and explain the actions we have taken or propose to take to address the issues raised in your complaint.  If you are not satisfied with DTA’s response to your complaint, you may ask for a review by a senior officer within DTA.  You may also lodge a complaint to the Office of the Australian Information Commissioner.
+We will respond to your complaint within 30 days (or another timeframe agreed with you) of receiving your complaint and explain the actions we have taken or propose to take to address the issues raised in your complaint.  If you are not satisfied with APSC’s response to your complaint, you may ask for a review by a senior officer within APSC.  You may also lodge a complaint to the Office of the Australian Information Commissioner.
 
 To lodge a complaint to the Office of the Australian Information Commissioner:
 

--- a/client/src/pages/register/success.tsx
+++ b/client/src/pages/register/success.tsx
@@ -16,7 +16,7 @@ const Content: React.FC<{opportunityId: number}> = ({opportunityId}) => {
         <li><Link to="/login">Login</Link> using your email and password.</li>
         <li>Enter the verification code from your email when prompted.</li>
       </ul>
-      <p>If you have any questions, please contact <a href="mailto:specialist.advice@dta.gov.au">specialist.advice@dta.gov.au</a>.</p>
+      <p>If you have any questions, please contact <a href="mailto:specialist.advice@apsc.gov.au">specialist.advice@apsc.gov.au</a>.</p>
     </>
   );
 }

--- a/client/src/pages/successfully-applied.tsx
+++ b/client/src/pages/successfully-applied.tsx
@@ -18,7 +18,7 @@ const Content: React.FC<{opportunityId: number}> = ({opportunityId}) => {
       <>
         <h1>You have applied for an opportunity</h1>
         <p>Your application for {data.jobTitle} has been received.</p>
-        <p>If you have any questions, please contact <a href="mailto:specialist.advice@dta.gov.au">specialist.advice@dta.gov.au</a>.</p>
+        <p>If you have any questions, please contact <a href="mailto:specialist.advice@apsc.gov.au">specialist.advice@apsc.gov.au</a>.</p>
         <p>Your next steps</p>
           <ul>
             <li><Link to={`/opportunity`}>Find</Link> more opportunities</li>

--- a/client/src/pages/successfully-posted.tsx
+++ b/client/src/pages/successfully-posted.tsx
@@ -32,7 +32,7 @@ const View: React.FC<{opportunityId: number}> = ({ opportunityId }) => {
               <p>More information about <Link to={"/help-pages/5-matching"}>Matching an applicant</Link>.</p>
               <h2>Share your feedback</h2>
               <p>As this is a pilot, we appreciate your feedback so we can improve our service.</p>
-              <p><a href="https://dta.syd1.qualtrics.com/jfe/form/SV_5t2zgcu4m6VHT0O" rel="noopener noreferrer" target="_blank">Complete a 3 minute survey</a>.</p>
+              <p><a href="https://apscommission.syd1.qualtrics.com/jfe/form/SV_57112z3fizC9d8W" rel="noopener noreferrer" target="_blank">Complete a 3 minute survey</a>.</p>
             </>
           )}
           {!data.publishedAt && (

--- a/client/src/sass/_footer.scss
+++ b/client/src/sass/_footer.scss
@@ -1,26 +1,6 @@
 .footer__affiliate {
   @include AU-fontgrid(xs);
 
-  .au-cta-link {
-    @include AU-fontgrid(xs);
-    display: inline-block;
-    font-weight: normal;
-    margin-top: 0;
-
-    &:after {
-      content: "";
-      @include AU-space(width, 0.75unit);
-      @include AU-space(height, 0.75unit);
-      @include AU-space(margin-left, 0.25unit);
-      display: inline-block;
-      vertical-align: middle;
-    }
-
-    &:hover:after {
-      @include AU-space(margin-left, 0.5unit);
-    }
-  }
-
   @include AU-media(md) {
     @include AU-space(padding, 0.5unit 0 0.5unit 1unit);
     border-left: solid 1px $AU-colordark-foreground-border;


### PR DESCRIPTION
This pull request replaces references to DTA, Digital Transformation Agency, email addresses and contact details with corresponding APSC details.